### PR TITLE
Fixes nav links on safari mobile.

### DIFF
--- a/site/css/default.css
+++ b/site/css/default.css
@@ -165,6 +165,11 @@ footer > ul > li > a {
   display: flex;
 }
 
+.mobile-logo {
+  position: initial;
+  z-index: 2;
+}
+
 .nav {
   backdrop-filter: blur(10px);
   height: 110px;
@@ -184,6 +189,8 @@ footer > ul > li > a {
   list-style: none;
   margin: 0;
   padding: 0;
+  position: initial;
+  z-index: 2;
 }
 
 .nav-item {
@@ -229,7 +236,7 @@ li > a:visited {
   height: 100%;
   display: flex;
   align-items: center;
-  margin-top: -70px;
+  margin-top: -60px;
   background: #653e70;
   border-radius: 20px;
   padding: 5px 0 30px 0;
@@ -300,6 +307,8 @@ li > a:visited {
   -moz-border-radius: 25px;
   -ms-border-radius: 25px;
   -o-border-radius: 25px;
+  position: initial;
+  z-index: 2;
 }
 
 .cta-large {

--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -39,7 +39,7 @@
             <a href="/projects/projects.html">Meet the Projects</a>
           </li>
         </ul>
-        <a href="/"
+        <a href="/" class="mobile-logo"
           ><svg
             width="41"
             height="37"


### PR DESCRIPTION
The nav links on safari mobile were not working due to a z-index issue. These changes fix that. 

Also added a little margin above the "A note from us..." section. Screenshots attached!
![Screen Shot 2023-07-08 at 12 09 01 PM](https://github.com/rebeccaskinner/effective-haskell.com/assets/65040368/b049b496-811a-4481-bc60-5d8b3faf0955)
![Screen Shot 2023-07-08 at 12 09 13 PM](https://github.com/rebeccaskinner/effective-haskell.com/assets/65040368/35afd694-91bb-4514-875b-86a9c761924c)
